### PR TITLE
Refactor: Client-side tool filtering and removal of mcp-readonly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,74 +1,7 @@
-/target
-
-# Byte-compiled / optimized / DLL files
+target/
+.coder_mcp/
 __pycache__/
-.pytest_cache/
-*.py[cod]
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
+*.pyc
 .venv/
-env/
-bin/
-build/
-develop-eggs/
-dist/
-eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-include/
-man/
-venv/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-pip-selfcheck.json
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.cache
-nosetests.xml
-coverage.xml
-
-# Translations
-*.mo
-
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Rope
-.ropeproject
-
-# Django stuff:
-*.log
-*.pot
-
-.DS_Store
-
-# Sphinx documentation
-docs/_build/
-
-# PyCharm
-.idea/
-
-# VSCode
-.vscode/
-
-# Pyenv
-.python-version
-
 .env
+verify_tree.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +195,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmcp",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -306,6 +319,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -503,9 +528,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -779,7 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -843,6 +886,17 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1474,6 +1528,20 @@ dependencies = [
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2227,6 +2295,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ regex = "1.12.2"
 walkdir = "2.5.0"
 portable-pty = "0.8"
 anyhow = "1.0"
+rusqlite = { version = "0.32", features = ["bundled"] }
 pyo3 = { version = "0.27.0", features = ["extension-module"] }
 pyo3-async-runtimes = { version = "0.27.0", features = ["tokio-runtime"] }
 

--- a/python/coder_mcp/runtime/runtime.py
+++ b/python/coder_mcp/runtime/runtime.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from agents.mcp import MCPServerStreamableHttp
+from coder_mcp.types import CoderToolName
 
 
 logger = logging.getLogger(__name__)
@@ -35,9 +36,23 @@ class Runtime(ABC):
         pass
 
     @abstractmethod
-    def coder_mcp(self) -> MCPServerStreamableHttp: ...
+    def coder_mcp(
+        self,
+        allowed_tool_names: list[CoderToolName] | None = None,
+        blocked_tool_names: list[CoderToolName] | None = None,
+    ) -> MCPServerStreamableHttp: ...
+
     @abstractmethod
     def coder_mcp_readonly(self) -> MCPServerStreamableHttp: ...
+
+    async def tree(
+        self,
+        path: str = ".",
+        exclude: list[str] | None = None,
+        truncate: int = 10,
+    ) -> str:
+        """Get the tree structure of the workspace."""
+        raise NotImplementedError
 
     async def _wait_for_health(self, url: str, timeout: float = 30.0):
         """Wait for the server to respond to health checks at the given URL."""

--- a/python/coder_mcp/types.py
+++ b/python/coder_mcp/types.py
@@ -1,0 +1,14 @@
+from typing import Literal
+
+CoderToolName = Literal[
+    "bash",
+    "view_file",
+    "list_directory",
+    "create_file",
+    "str_replace",
+    "insert_lines",
+    "delete_file",
+    "undo_edit",
+    "search_filenames",
+    "search_content",
+]

--- a/tests/test_tool_filter.py
+++ b/tests/test_tool_filter.py
@@ -1,0 +1,76 @@
+import asyncio
+import logging
+import sys
+from coder_mcp.runtime.local_runtime import LocalRuntime
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def test_tool_filter():
+    print("--- Starting Tool Filter Test ---")
+    async with LocalRuntime(workdir=".") as runtime:
+        # Test 1: Bash only
+        print("\n[Test 1] Connecting with allowed_tool_names=['bash']...")
+        async with runtime.coder_mcp(allowed_tool_names=["bash"]) as client:
+            tools = await client.list_tools()
+            # tools is a list of Tool objects
+            tool_names = [t.name for t in tools]
+            print(f"Available tools: {tool_names}")
+
+            if "bash" not in tool_names:
+                print("FAIL: 'bash' not found in tools")
+                sys.exit(1)
+
+            if "view_file" in tool_names:
+                print("FAIL: 'view_file' should NOT be in tools")
+                sys.exit(1)
+
+            # Try calling bash
+            print("Calling 'bash' tool...")
+            try:
+                result = await client.call_tool(
+                    "bash", {"command": "echo 'Hello Bash'"}
+                )
+                print(f"Result: {result}")
+            except Exception as e:
+                print(f"FAIL: Failed to call bash: {e}")
+                sys.exit(1)
+
+        # Test 2: Read-only defaults
+        print("\n[Test 2] Connecting with coder_mcp_readonly()...")
+        async with runtime.coder_mcp_readonly() as client:
+            tools = await client.list_tools()
+            tool_names = [t.name for t in tools]
+            print(f"Available tools: {tool_names}")
+
+            allowed_readonly = [
+                "view_file",
+                "list_directory",
+                "search_filenames",
+                "search_content",
+            ]
+            for t in tool_names:
+                if t not in allowed_readonly:
+                    print(f"FAIL: Tool '{t}' should NOT be available in read-only mode")
+                    sys.exit(1)
+
+            if "bash" in tool_names:
+                print("FAIL: 'bash' should NOT be in read-only tools")
+                sys.exit(1)
+
+            # Try calling view_file (should work)
+            print("Calling 'list_directory'...")
+            try:
+                await client.call_tool("list_directory", {"path": "."})
+                print("Success calling 'list_directory'")
+            except Exception as e:
+                print(f"FAIL: Failed to call list_directory: {e}")
+                sys.exit(1)
+
+    print("\n--- All Tests Passed ---")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_tool_filter())


### PR DESCRIPTION
Refactors the tool selection mechanism to use client-side filtering via `tool_filter` in `MCPServerStreamableHttp`. Removes the redundant `mcp-readonly` endpoint and `CoderMcpReadOnlyService` from the server. cleanup: includes fixes for memory leaks and DRY violations from previous work.